### PR TITLE
   This commit fixes two critical deployment issues:

### DIFF
--- a/.github/workflows/deploy-raspi.yml
+++ b/.github/workflows/deploy-raspi.yml
@@ -36,9 +36,24 @@ jobs:
           mkdir -p /projects/ai-support-bot
           cd /projects/ai-support-bot
 
-          # Create data directories
-          mkdir -p data/database data/storage data/cache data/redis
-          chmod -R 777 data
+          # Create data directories and subdirectories for proper volume mounting
+          mkdir -p data/database
+          mkdir -p data/storage/app/public
+          mkdir -p data/storage/framework/cache/data
+          mkdir -p data/storage/framework/sessions
+          mkdir -p data/storage/framework/testing
+          mkdir -p data/storage/framework/views
+          mkdir -p data/storage/logs
+          mkdir -p data/cache
+          mkdir -p data/redis
+
+          # Create SQLite database file if it doesn't exist
+          touch data/database/database.sqlite
+
+          # Set proper ownership (github user on host, 1337 is 'sail' user in container)
+          # Use current user (github) for host access, but ensure container can write
+          sudo chown -R github:github data
+          sudo chmod -R 777 data
 
       - name: 5. Checkout Compose Files
         run: |
@@ -95,11 +110,19 @@ jobs:
           # Stop and remove old containers
           docker compose down
 
+          # Ensure permissions are correct before starting containers
+          sudo chown -R github:github data
+          sudo chmod -R 777 data
+
           # Start services with new image
           docker compose up -d
 
           # Wait for services to be healthy
           sleep 10
+
+          # Fix permissions after container creates any new files
+          sudo chown -R github:github data
+          sudo chmod -R 777 data
 
       - name: 9. Run Database Migrations
         run: |

--- a/compose.override.production.yml
+++ b/compose.override.production.yml
@@ -13,9 +13,12 @@ services:
       - '${APP_PORT:-80}:80'
 
     # Production volumes - persistent data on host
+    # IMPORTANT: Only mount specific subdirectories to avoid wiping out the application code
     volumes:
-      - /projects/ai-support-bot/data/database:/var/www/html/database
-      - /projects/ai-support-bot/data/storage:/var/www/html/storage
+      - /projects/ai-support-bot/data/storage/app:/var/www/html/storage/app
+      - /projects/ai-support-bot/data/storage/framework:/var/www/html/storage/framework
+      - /projects/ai-support-bot/data/storage/logs:/var/www/html/storage/logs
+      - /projects/ai-support-bot/data/database/database.sqlite:/var/www/html/database/database.sqlite
       - /projects/ai-support-bot/data/cache:/var/www/html/bootstrap/cache
 
     # Production environment variables


### PR DESCRIPTION
   1. **Volume mounting issue**: Changed from mounting entire directories to specific subdirectories to prevent wiping out application code built into the Docker image. This was causing "Could not open input file: /var/www/html/artisan" errors.

   2. **Permission issues**: Added automatic permission fixes using the github user (self-hosted runner user) with proper chown/chmod commands at multiple stages of deployment to prevent permission errors that required manual intervention on each deploy.

   Changes:
   - compose.override.production.yml: Mount only storage subdirectories and the SQLite database file instead of entire directories
   - deploy-raspi.yml: Create proper directory structure, set github user ownership, and fix permissions before/after container startup

   🤖 Generated with [Claude Code](https://claude.com/claude-code)