### PR TITLE
   This commit fixes two critical deployment issues:

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -40,6 +40,9 @@ jobs:
           platforms: linux/arm/v7,linux/arm64 # Support both Raspberry Pi 2 (ARMv7) and newer models (ARM64)
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/ai-support-bot:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/ai-support-bot:buildcache,mode=max
+          build-args: |
+            VITE_TELEGRAM_BOT_USERNAME=${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+            VITE_APP_NAME=${{ vars.VITE_APP_NAME || 'AI Support Bot' }}
 
       - name: Dispatch Deployment Job to Pi Runner
         # Після успішної збірки, ми "повідомляємо" Raspberry Pi Runner

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -5,6 +5,8 @@ LABEL description="Production-optimized ARM64 image for Raspberry Pi"
 
 ARG WWWGROUP=1000
 ARG NODE_VERSION=22
+ARG VITE_TELEGRAM_BOT_USERNAME=placeholder
+ARG VITE_APP_NAME="AI Support Bot"
 
 WORKDIR /var/www/html
 
@@ -82,7 +84,7 @@ RUN composer install --no-dev --optimize-autoloader --no-interaction --prefer-di
 # Note: Vite variables are baked into the build, but for bot username we can use a placeholder
 # The actual bot interaction happens server-side via TELEGRAPH_BOT_NAME
 RUN npm ci --production=false \
-    && VITE_TELEGRAM_BOT_USERNAME="placeholder" VITE_APP_NAME="AI Support Bot" npm run build \
+    && VITE_TELEGRAM_BOT_USERNAME="$VITE_TELEGRAM_BOT_USERNAME" VITE_APP_NAME="$VITE_APP_NAME" npm run build \
     && rm -rf node_modules \
     && npm cache clean --force
 


### PR DESCRIPTION
   1. **Volume mounting issue**: Changed from mounting entire directories to specific subdirectories to prevent wiping out application code built into the Docker image. This was causing "Could not open input file: /var/www/html/artisan" errors.

   2. **Permission issues**: Added automatic permission fixes using the github user (self-hosted runner user) with proper chown/chmod commands at multiple stages of deployment to prevent permission errors that required manual intervention on each deploy.

   Changes:
   - compose.override.production.yml: Mount only storage subdirectories and the SQLite database file instead of entire directories
   - deploy-raspi.yml: Create proper directory structure, set github user ownership, and fix permissions before/after container startup

   🤖 Generated with [Claude Code](https://claude.com/claude-code)