### PR TITLE
fix: resolve Docker Compose network_mode and networks conflict

### DIFF
--- a/.github/workflows/deploy-raspi.yml
+++ b/.github/workflows/deploy-raspi.yml
@@ -73,6 +73,7 @@ jobs:
             echo "GEMINI_MODEL=\"${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}\""
             echo "TELEGRAM_TOKEN=\"${{ secrets.TELEGRAM_TOKEN }}\""
             echo "TELEGRAM_BOT_USERNAME=\"${{ vars.TELEGRAM_BOT_USERNAME }}\""
+            echo "TELEGRAPH_WEBHOOK_URL=\"${{ vars.TELEGRAPH_WEBHOOK_URL || '' }}\""
             echo ""
             echo "DOCKER_IMAGE=${{ secrets.DOCKER_USERNAME }}/ai-support-bot:${{ env.IMAGE_TAG }}"
           } > .env 2>&1

--- a/compose.override.raspberry.yml
+++ b/compose.override.raspberry.yml
@@ -7,6 +7,7 @@ services:
     # Use pre-built production image instead of building locally
     image: ${DOCKER_IMAGE:-sergeyphpdevua/ai-support-bot:latest}
     build: null  # Disable build, use image from Docker Hub
+    networks: null  # Disable networks when using network_mode: host
 
     # Production ports (only HTTP, no Vite dev server)
     ports:


### PR DESCRIPTION
- Fix mutually exclusive network_mode: host and networks in compose.override.raspberry.yml
- Add missing TELEGRAPH_WEBHOOK_URL env var to prevent deployment warnings